### PR TITLE
Set neutron_driver to null

### DIFF
--- a/Openstack_2.x_Build_Instructions/config_files/containers-prepare-parameter.yaml
+++ b/Openstack_2.x_Build_Instructions/config_files/containers-prepare-parameter.yaml
@@ -26,7 +26,7 @@ parameter_defaults:
       name_prefix: openstack-
       name_suffix: ''
       namespace: registry.redhat.io/rhosp-rhel8
-      neutron_driver: openvswitch
+      neutron_driver: null
       rhel_containers: false
       tag: '16.1'
     tag_from_label: '{version}-{release}'


### PR DESCRIPTION
With neutron_driver set to openvswitch, the
overcloud deploy is trying to pull OVN
containers. Setting it to null as per the
guide:
https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html-single/network_functions_virtualization_planning_and_configuration_guide/index#deploying_rhosp_with_the_ovs_mechanism_driver

With this set to null, we should exit here:
https://github.com/openstack/tripleo-common/blob/stable/train/tripleo_common/update.py#L50-L52

Else openvswitch is in the constants.EXCLUSIVE_NEUTRON_DRIVERS list:
https://github.com/openstack/tripleo-common/blob/stable/train/tripleo_common/constants.py#L219

Resolves: 03082681